### PR TITLE
Update utils.h

### DIFF
--- a/c/time/utils.h
+++ b/c/time/utils.h
@@ -23,7 +23,7 @@ unsigned long long gettime(void)
 		exit(1);
 	}
 
-	return t.tv_sec * SECONDS + t.tv_nsec * NANOSECONDS;
+	return (unsigned long long) t.tv_sec * SECONDS + t.tv_nsec * NANOSECONDS;
 }
 
 void test_start(void)


### PR DESCRIPTION
In some (32 bit) systems time_t is only 4 bytes long so (t.tv_sec \* SECONDS) can easily overflow if you don't convert at least one of them to ULL.
